### PR TITLE
Add cite tag to html block definitions for semantic blockquote markup

### DIFF
--- a/src/types/shared/block-definitions.php
+++ b/src/types/shared/block-definitions.php
@@ -184,6 +184,10 @@ class BlockDefinitions {
 				'root_only' => false,
 				'allow_root' => false,
 			],
+			'cite' => [
+				'root_only' => false,
+				'allow_root' => false,
+			],
 			'code' => [
 				'root_only' => false,
 				'allow_root' => false,


### PR DESCRIPTION
Fixes #10 

Added `cite` tag to html block definitions to return `blockquote` semantic markup.