### PR TITLE
add a tag to allowed parents of img block type

### DIFF
--- a/src/types/shared/block-definitions.php
+++ b/src/types/shared/block-definitions.php
@@ -233,7 +233,7 @@ class BlockDefinitions {
 				'allow_root' => false,
 			],
 			'img' => [
-				'allowed_parent_types' => [ 'figure' ],
+				'allowed_parent_types' => [ 'figure', 'a'],
 			],
 			'li' => [
 				'root_only' => false,


### PR DESCRIPTION
Noticed that images with links wouldn't come through on the API
Added a tag to the allowed parents fixes this